### PR TITLE
Add sbt-github-actions-logger

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.12.0")
 addSbtPlugin("com.github.sideeffffect" % "sbt-decent-scala" % "1.1.66")
+addSbtPlugin("com.github.sideeffffect" % "sbt-github-actions-logger" % "1.1.0")


### PR DESCRIPTION
Adds [sbt-github-actions-logger](https://github.com/sideeffffect/sbt-github-actions-logger) 1.1.0 to `project/plugins.sbt`, so this build's compiler warnings/errors show up as inline GitHub Actions annotations and compilation/test output is folded into collapsible log groups in CI. It only activates when `GITHUB_ACTIONS=true`, so local builds are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)